### PR TITLE
Clean the Clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,8 +31,7 @@ fn main() -> Result<()> {
             let cell_pointers = database[108..]
                 .chunks_exact(2)
                 .take(page_header.number_of_cells.into())
-                .map(|bytes| u16::from_be_bytes(bytes.try_into().unwrap()))
-                .collect::<Vec<_>>();
+                .map(|bytes| u16::from_be_bytes(bytes.try_into().unwrap()));
 
             // Obtain all records from column 5
             #[allow(unused_variables)]

--- a/src/record.rs
+++ b/src/record.rs
@@ -18,7 +18,7 @@ pub fn parse_record(stream: &[u8], column_count: usize) -> Result<Vec<Vec<u8>>> 
     // Parse each serial type as column into record and modify the offset
     let mut record = vec![];
     for serial_type in serial_types {
-        let column = parse_column_value(&stream[offset..], serial_type as usize)?;
+        let column = parse_column_value(&stream[offset..], serial_type)?;
         offset += column.len();
         record.push(column);
     }
@@ -33,7 +33,7 @@ fn parse_column_value(stream: &[u8], serial_type: usize) -> Result<Vec<u8>> {
         // Text encoding
         n if serial_type >= 13 && serial_type % 2 == 1 => {
             let n_bytes = (n - 13) / 2;
-            let bytes = stream[0..n_bytes as usize].to_vec();
+            let bytes = stream[0..n_bytes].to_vec();
             bytes
         }
         _ => bail!("Invalid serial_type: {}", serial_type),

--- a/src/record.rs
+++ b/src/record.rs
@@ -33,8 +33,7 @@ fn parse_column_value(stream: &[u8], serial_type: usize) -> Result<Vec<u8>> {
         // Text encoding
         n if serial_type >= 13 && serial_type % 2 == 1 => {
             let n_bytes = (n - 13) / 2;
-            let bytes = stream[0..n_bytes].to_vec();
-            bytes
+            stream[0..n_bytes].to_vec()
         }
         _ => bail!("Invalid serial_type: {}", serial_type),
     };

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -31,10 +31,11 @@ impl Schema {
 /// parses variable size unsigned integer encoded as bytes to number.
 fn parse_number(bytes: &[u8]) -> usize {
     let mut result: usize = 0;
-    let num_bytes = bytes.len();
-    for i in 0..num_bytes {
-        let shift = (num_bytes - i - 1) * 8;
-        result += (bytes[i] as usize) << shift;
+
+    for (i, byte) in bytes.iter().enumerate() {
+        let shift = (bytes.len() - i - 1) * 8;
+        result += (*byte as usize) << shift;
     }
+
     result
 }

--- a/src/varint.rs
+++ b/src/varint.rs
@@ -30,10 +30,9 @@ fn usable_value(usable_size: u8, byte: u8) -> u8 {
 fn read_usable_bytes(stream: &[u8]) -> Vec<u8> {
     let mut usable_bytes = vec![];
 
-    for i in 0..9 {
-        let byte = stream[i];
-        usable_bytes.push(byte);
-        if starts_with_zero(byte) {
+    for byte in stream.iter().take(9) {
+        usable_bytes.push(*byte);
+        if starts_with_zero(*byte) {
             break;
         }
     }


### PR DESCRIPTION
Clean the Clippy warnings; some cases are redundancies, some others are non-idiomatic Rust constructs.

Comments are in each commit.

I haven't converted the Rust edition to 2021, since that may potentially interfere with the service build.

Something that I also suggest (it's not a Clippy warning) is to make the [Schema::parse](https://github.com/64kramsystem/sqlite-starter-rust-dev/blob/master/src/schema.rs#L12) method borrow rather than own the input parameter, as, in the current form, it prevents reusing it (in my solution for example, I did reuse the `record` variable).